### PR TITLE
New PVR features for MediaPortal TV-Server and ArgusTV backends

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -283,6 +283,10 @@
     <ClCompile Include="..\..\xbmc\cores\DSPlayer\MadvrCallback.cpp" />
     <ClCompile Include="..\..\xbmc\cores\DSPlayer\PixelShaderCompiler.cpp" />
     <ClCompile Include="..\..\xbmc\cores\DSPlayer\PixelShaderList.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSArgusTV.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSMediaPortal.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSPVRBackend.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSSocket.cpp" />
     <ClCompile Include="..\..\xbmc\cores\DSPlayer\ShadersSelectionRule.cpp" />
     <ClCompile Include="..\..\xbmc\cores\DSPlayer\StreamsManager.cpp" />
     <ClCompile Include="..\..\xbmc\cores\DSPlayer\Subtitles\decss\CSSauth.cpp" />
@@ -989,6 +993,10 @@
     <ClInclude Include="..\..\xbmc\cores\DSPlayer\moreuuids.h" />
     <ClInclude Include="..\..\xbmc\cores\DSPlayer\PixelShaderCompiler.h" />
     <ClInclude Include="..\..\xbmc\cores\DSPlayer\PixelShaderList.h" />
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSArgusTV.h" />
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSMediaPortal.h" />
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSPVRBackend.h" />
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSSocket.h" />
     <ClInclude Include="..\..\xbmc\cores\DSPlayer\ShadersSelectionRule.h" />
     <ClInclude Include="..\..\xbmc\cores\DSPlayer\StreamsManager.h" />
     <ClInclude Include="..\..\xbmc\cores\DSPlayer\Subtitles\decss\CSSauth.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -379,6 +379,9 @@
     <Filter Include="shaders">
       <UniqueIdentifier>{9fe3f6e1-16d1-4437-b859-1b183adcef22}</UniqueIdentifier>
     </Filter>
+    <Filter Include="cores\DSPlayer\PVR">
+      <UniqueIdentifier>{8ac06bad-d1c3-4388-bdaf-01384aa9ace1}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -3297,6 +3300,18 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\cores\DSPlayer\Dialogs\GUIDialogLAVSplitter.cpp">
       <Filter>cores\DSPlayer\Dialogs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSArgusTV.cpp">
+      <Filter>cores\DSPlayer\PVR</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSMediaPortal.cpp">
+      <Filter>cores\DSPlayer\PVR</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSPVRBackend.cpp">
+      <Filter>cores\DSPlayer\PVR</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\DSPlayer\PVR\DSSocket.cpp">
+      <Filter>cores\DSPlayer\PVR</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -6420,6 +6435,18 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\DSPlayer\Dialogs\GUIDialogLAVSplitter.h">
       <Filter>cores\DSPlayer\Dialogs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSArgusTV.h">
+      <Filter>cores\DSPlayer\PVR</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSMediaPortal.h">
+      <Filter>cores\DSPlayer\PVR</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSPVRBackend.h">
+      <Filter>cores\DSPlayer\PVR</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\DSPlayer\PVR\DSSocket.h">
+      <Filter>cores\DSPlayer\PVR</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/cores/DSPlayer/DSInputStreamPVRManager.cpp
+++ b/xbmc/cores/DSPlayer/DSInputStreamPVRManager.cpp
@@ -1,23 +1,26 @@
 /*
- *  Copyright (C) 2010-2013 Eduard Kytmanov
- *  http://www.avmedia.su
- *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with GNU Make; see the file COPYING.  If not, write to
- *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
- *  http://www.gnu.org/copyleft/gpl.html
- *
- */
+*  Copyright (C) 2010-2013 Eduard Kytmanov
+*  http://www.avmedia.su
+*
+*  Copyright (C) 2015 Romank
+*  https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with GNU Make; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
 
 #ifdef HAS_DS_PLAYER
 
@@ -28,6 +31,8 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "settings/AdvancedSettings.h"
 
 CDSInputStreamPVRManager* g_pPVRStream = NULL;
 
@@ -36,9 +41,9 @@ CDSInputStreamPVRManager::CDSInputStreamPVRManager(CDSPlayer *pPlayer)
   , m_pFile(NULL)
   , m_pLiveTV(NULL)
   , m_pRecordable(NULL)
+  , m_pPVRBackend(NULL)
 {
 }
-
 
 CDSInputStreamPVRManager::~CDSInputStreamPVRManager(void)
 {
@@ -52,107 +57,323 @@ void CDSInputStreamPVRManager::Close()
     m_pFile->Close();
     SAFE_DELETE(m_pFile);
   }
-
+  SAFE_DELETE(m_pPVRBackend);
   m_pLiveTV = NULL;
   m_pRecordable = NULL;
+}
+
+bool CDSInputStreamPVRManager::CloseAndOpenFile(const CURL& url)
+{
+  if (!m_pFile)
+    return false;
+
+  // In case opened channel need to be closed before opening new channel
+  bool bReturnVal = false;
+  if (CDSPlayer::PlayerState == DSPLAYER_PLAYING || CDSPlayer::PlayerState == DSPLAYER_PAUSED)
+  {
+    // New channel cannot be opened, try to close the file
+    m_pPlayer->CloseFile(false);
+    bReturnVal = m_pPlayer->WaitForThreadExit(100);
+
+    if (!bReturnVal)
+      CLog::Log(LOGERROR, "%s Closing file failed", __FUNCTION__);
+
+    if (bReturnVal)
+    {
+      // Try to open the file
+      bReturnVal = false;
+      for (int iRetry = 0; iRetry < 10 && !bReturnVal; iRetry++)
+      {
+        if (m_pFile->Open(url))
+          bReturnVal = true;
+        else
+          Sleep(500);
+      }
+    }
+  }
+
+  if (bReturnVal)
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, "DSPlayer", "File opened successfully", TOAST_MESSAGE_TIME, false);
+
+  return bReturnVal;
 }
 
 bool CDSInputStreamPVRManager::Open(const CFileItem& file)
 {
   Close();
 
+  bool bReturnVal = false;
+  std::string strTranslatedPVRFile;
   m_pFile = new CPVRFile;
 
   CURL url(file.GetPath());
-  if (!m_pFile->Open(url))
+  bReturnVal = m_pFile->Open(url);
+  if (!bReturnVal)
+    bReturnVal = CloseAndOpenFile(url);
+
+  if (bReturnVal)
   {
-    SAFE_DELETE(m_pFile);
-    return false;
+    m_pLiveTV = ((CPVRFile*)m_pFile)->GetLiveTV();
+    m_pRecordable = ((CPVRFile*)m_pFile)->GetRecordable();
+    m_pPVRBackend = GetPVRBackend();
+
+    if (file.IsLiveTV())
+    {
+      bReturnVal = true;
+      strTranslatedPVRFile = XFILE::CPVRFile::TranslatePVRFilename(file.GetPath());
+      if (strTranslatedPVRFile == file.GetPath())
+      {
+        if (file.HasPVRChannelInfoTag())
+          strTranslatedPVRFile = g_PVRClients->GetStreamURL(file.GetPVRChannelInfoTag());
+      }
+
+      // Check if LiveTV file path is valid for DSPlayer.
+      if (URIUtils::IsLiveTV(strTranslatedPVRFile))
+        bReturnVal = false;
+
+      // Convert Stream URL To TimeShift file path 
+      if (bReturnVal && g_advancedSettings.m_bDSPlayerUseUNCPathsForLiveTV)
+      {
+        if (m_pPVRBackend && m_pPVRBackend->SupportsStreamConversion(strTranslatedPVRFile))
+        {
+          CStdString strTimeShiftFile;
+          bReturnVal = m_pPVRBackend->ConvertStreamURLToTimeShiftFilePath(strTranslatedPVRFile, strTimeShiftFile);
+          if (bReturnVal)
+            strTranslatedPVRFile = strTimeShiftFile;
+        }
+        else
+        {
+          CLog::Log(LOGERROR, "%s Stream conversion is not supported for this PVR Backend url: %s", __FUNCTION__, strTranslatedPVRFile.c_str());
+        }
+      }
+    }
+    else if (m_pPVRBackend && file.IsPVRRecording())
+    {
+      if (file.HasPVRRecordingInfoTag())
+      {
+        CPVRRecordingPtr recordingPtr = file.GetPVRRecordingInfoTag();
+        CStdString strRecordingUrl;
+        bReturnVal = m_pPVRBackend->GetRecordingStreamURL(recordingPtr->m_strRecordingId, strRecordingUrl, g_advancedSettings.m_bDSPlayerUseUNCPathsForLiveTV);
+        if (bReturnVal)
+          strTranslatedPVRFile = strRecordingUrl;
+      }
+    }
   }
 
-  m_pLiveTV = ((CPVRFile*)m_pFile)->GetLiveTV();
-  m_pRecordable = ((CPVRFile*)m_pFile)->GetRecordable();
-
-  std::string transFile = XFILE::CPVRFile::TranslatePVRFilename(file.GetPath());
-
-  if (transFile == file.GetPath())
+  if (bReturnVal)
   {
-    CFileItemPtr channel = g_PVRChannelGroups->GetByPath(file.GetPath());
-    if (channel && channel->HasPVRChannelInfoTag())
-      transFile = g_PVRClients->GetStreamURL(channel->GetPVRChannelInfoTag());
+    CFileItem fileItem = file;
+    fileItem.SetPath(strTranslatedPVRFile);
+    bReturnVal = m_pPlayer->OpenFileInternal(fileItem);
   }
-  CFileItem fileItem = file;
-  fileItem.SetPath(transFile);
+  else
+  {
+    std::string strMessage = StringUtils::Format("Opening %s failed", file.IsLiveTV() ? "channel" : "recording");
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, "DSPlayer", strMessage, TOAST_DISPLAY_TIME, false);
+    CLog::Log(LOGERROR, "%s %s", __FUNCTION__, strMessage.c_str());
+  }
 
-  return m_pPlayer->OpenFileInternal(fileItem);
+  return bReturnVal;
+}
+
+bool  CDSInputStreamPVRManager::PrepareForChannelSwitch(const CPVRChannelPtr &channel)
+{
+  // Workaround for MediaPortal addon, running in ffmpeg mode.
+  if (m_pPVRBackend && m_pPVRBackend->GetBackendName().find("MediaPortal TV-server") != std::string::npos)
+  {
+    // Opened new channel manually.
+    // This will prevent from SwitchChannel() method to fail.
+    g_PVRClients->GetStreamURL(channel);
+
+    // Clear StreamURL field of CurrentChannel 
+    // that's used in CPVRClients::SwitchChannel()
+    g_PVRManager.GetCurrentChannel()->SetStreamURL("");
+
+    // Clear StreamURL field of new channel that's
+    // used in CPVRManager::ChannelSwitch()
+    channel->SetStreamURL("");
+  }
+
+  return true;
+}
+
+bool CDSInputStreamPVRManager::PerformChannelSwitch()
+{
+  bool bResult = false;
+  CFileItem fileItem;
+  bResult = GetNewChannel(fileItem);
+  if (bResult)
+  {
+    if (m_pPlayer->currentFileItem.GetPath() != fileItem.GetPath())
+    {
+      // File changed - fast channel switching is not possible
+      CLog::Log(LOGNOTICE, "%s - File changed - fast channel switching is not possible, opening new channel...", __FUNCTION__);
+      bResult = m_pPlayer->OpenFileInternal(fileItem);
+    }
+    else
+    {
+      // File not changed - channel switch complete successfully.
+      m_pPlayer->UpdateApplication();
+      m_pPlayer->UpdateChannelSwitchSettings();
+      CLog::Log(LOGNOTICE, "%s - Channel switch complete successfully", __FUNCTION__);
+    }
+  }
+
+  return bResult;
+}
+
+bool CDSInputStreamPVRManager::GetNewChannel(CFileItem& fileItem)
+{
+  bool bResult = false;
+  CPVRChannelPtr channelPtr(g_PVRManager.GetCurrentChannel());
+  if (channelPtr)
+  {
+    std::string strNewFile = g_PVRClients->GetStreamURL(channelPtr);
+    if (!strNewFile.empty())
+    {
+      bResult = true;
+      // Convert Stream URL To TimeShift file
+      if (g_advancedSettings.m_bDSPlayerUseUNCPathsForLiveTV && m_pPVRBackend && m_pPVRBackend->SupportsStreamConversion(strNewFile))
+      {
+        CStdString timeShiftFile = "";
+        if (m_pPVRBackend->ConvertStreamURLToTimeShiftFilePath(strNewFile, timeShiftFile))
+          strNewFile = timeShiftFile;
+      }
+
+      CFileItem newFileItem(channelPtr);
+      fileItem = newFileItem;
+      fileItem.SetPath(strNewFile);
+      CLog::Log(LOGNOTICE, "%s - New channel file path: %s", __FUNCTION__, strNewFile.c_str());
+    }
+  }
+
+  if (!bResult)
+    CLog::Log(LOGERROR, "%s - Failed to get file path of the new channel", __FUNCTION__);
+
+  return bResult;
 }
 
 bool CDSInputStreamPVRManager::SelectChannel(const CPVRChannelPtr &channel)
 {
+  bool bResult = false;
+
   if (!SupportsChannelSwitch())
   {
     CFileItem item(channel);
-    return Open(item);
+    bResult = Open(item);
   }
   else if (m_pLiveTV)
   {
-    return m_pLiveTV->SelectChannel(channel->ChannelNumber());
+    PrepareForChannelSwitch(channel);
+    bResult = m_pLiveTV->SelectChannel(channel->ChannelNumber());
+    if (bResult)
+      bResult = PerformChannelSwitch();
   }
-  return false;
+
+  return bResult;
 }
 
 bool CDSInputStreamPVRManager::NextChannel(bool preview /* = false */)
 {
+  bool bResult = false;
   PVR_CLIENT client;
+
+  CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
+  CFileItemPtr item = g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelUp(channel);
+  if (!item || !item->HasPVRChannelInfoTag())
+  {
+    CLog::Log(LOGERROR, "%s - Cannot find the channel", __FUNCTION__);
+    return false;
+  }
+
   if (!preview && !SupportsChannelSwitch())
   {
-    CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
-    CFileItemPtr item = g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelUp(channel);
     if (item.get())
-      return Open(*item.get());
+      bResult = Open(*item.get());
   }
   else if (m_pLiveTV)
-    return m_pLiveTV->PrevChannel(preview);
+  {
+    PrepareForChannelSwitch(item->GetPVRChannelInfoTag());
+    bResult = m_pLiveTV->NextChannel(preview);
+    if (bResult)
+      bResult = PerformChannelSwitch();
+  }
 
-  return false;
+  return bResult;
 }
 
 bool CDSInputStreamPVRManager::PrevChannel(bool preview/* = false*/)
 {
+  bool bResult = false;
   PVR_CLIENT client;
+
+  CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
+  CFileItemPtr item = g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelDown(channel);
+  if (!item || !item->HasPVRChannelInfoTag())
+  {
+    CLog::Log(LOGERROR, "%s - Cannot find the channel", __FUNCTION__);
+    return false;
+  }
+
   if (!preview && !SupportsChannelSwitch())
   {
-    CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
-    CFileItemPtr item = g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelDown(channel);
     if (item.get())
-      return Open(*item.get());
+      bResult = Open(*item.get());
   }
   else if (m_pLiveTV)
-    return m_pLiveTV->PrevChannel(preview);
-  return false;
+  {
+    PrepareForChannelSwitch(item->GetPVRChannelInfoTag());
+    bResult = m_pLiveTV->PrevChannel(preview);
+    if (bResult)
+      bResult = PerformChannelSwitch();
+  }
+
+  return bResult;
 }
 
 bool CDSInputStreamPVRManager::SelectChannelByNumber(unsigned int iChannelNumber)
 {
+  bool bResult = false;
   PVR_CLIENT client;
+
+  CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
+  CFileItemPtr item = g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelNumber(iChannelNumber);
+  if (!item || !item->HasPVRChannelInfoTag())
+  {
+    CLog::Log(LOGERROR, "%s - Cannot find the channel %d", __FUNCTION__, iChannelNumber);
+    return false;
+  }
+
   if (!SupportsChannelSwitch())
   {
-    CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
-    CFileItemPtr item = g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelNumber(iChannelNumber);
     if (item.get())
-      return Open(*item.get());
+      bResult = Open(*item.get());
   }
   else if (m_pLiveTV)
-    return m_pLiveTV->SelectChannel(iChannelNumber);
+  {
+    PrepareForChannelSwitch(item->GetPVRChannelInfoTag());
+    bResult = m_pLiveTV->SelectChannel(iChannelNumber);
+    if (bResult)
+      bResult = PerformChannelSwitch();
+  }
 
-  return false;
+  return bResult;
 }
 
 bool CDSInputStreamPVRManager::SupportsChannelSwitch()const
 {
-  return false;
-  PVR_CLIENT client;
-  return g_PVRClients->GetPlayingClient(client) && client->HandlesInputStream();
+  if (!m_pPVRBackend || !g_advancedSettings.m_bDSPlayerFastChannelSwitching)
+    return false;
+
+  PVR_CLIENT pvrClient;
+  if (!g_PVRClients->GetPlayingClient(pvrClient))
+    return false;
+
+  // Check if active PVR Backend addon has changed or PVR Backend addon does not support channel switching
+  if (pvrClient->GetBackendName() != m_pPVRBackend->GetBackendName() || !m_pPVRBackend->SupportsFastChannelSwitch())
+    return false;
+
+  return pvrClient->HandlesInputStream();
 }
 
 bool CDSInputStreamPVRManager::UpdateItem(CFileItem& item)
@@ -160,6 +381,28 @@ bool CDSInputStreamPVRManager::UpdateItem(CFileItem& item)
   if (m_pLiveTV)
     return m_pLiveTV->UpdateItem(item);
   return false;
+}
+
+CDSPVRBackend* CDSInputStreamPVRManager::GetPVRBackend()
+{
+  PVR_CLIENT pvrClient;
+  if (!g_PVRClients->GetPlayingClient(pvrClient))
+  {
+    CLog::Log(LOGERROR, "%s - Failed to get PVR Client", __FUNCTION__);
+    return NULL;
+  }
+
+  CDSPVRBackend* pPVRBackend = NULL;
+  if (pvrClient->GetBackendName().find("MediaPortal TV-server") != std::string::npos)
+  {
+    pPVRBackend = new CDSMediaPortal(pvrClient->GetConnectionString(), pvrClient->GetBackendName());
+  }
+  else if (pvrClient->GetBackendName().find("ARGUS TV") != std::string::npos)
+  {
+    pPVRBackend = new CDSArgusTV(pvrClient->GetConnectionString(), pvrClient->GetBackendName());
+  }
+
+  return pPVRBackend;
 }
 
 uint64_t CDSInputStreamPVRManager::GetTotalTime()

--- a/xbmc/cores/DSPlayer/DSInputStreamPVRManager.h
+++ b/xbmc/cores/DSPlayer/DSInputStreamPVRManager.h
@@ -1,23 +1,26 @@
 /*
- *  Copyright (C) 2010-2013 Eduard Kytmanov
- *  http://www.avmedia.su
- *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with GNU Make; see the file COPYING.  If not, write to
- *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
- *  http://www.gnu.org/copyleft/gpl.html
- *
- */
+*  Copyright (C) 2010-2013 Eduard Kytmanov
+*  http://www.avmedia.su
+*
+*  Copyright (C) 2015 Romank
+*  https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with GNU Make; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
 
 #ifndef HAS_DS_PLAYER
 #error DSPlayer's header file included without HAS_DS_PLAYER defined
@@ -27,33 +30,43 @@
 #include "filesystem/ILiveTV.h"
 #include "DSPlayer.h"
 
+#include "PVR/DSPVRBackend.h"
+#include "PVR/DSArgusTV.h"
+#include "PVR/DSMediaPortal.h"
+
 using namespace XFILE;
 using namespace PVR;
 
 class CDSInputStreamPVRManager
 {
-  CDSPlayer					*m_pPlayer;
-  IFile						*m_pFile;
-  ILiveTVInterface			*m_pLiveTV;
-  IRecordable				*m_pRecordable;
+  CDSPlayer             *m_pPlayer;
+  IFile                 *m_pFile;
+  ILiveTVInterface	    *m_pLiveTV;
+  IRecordable           *m_pRecordable;
+  CDSPVRBackend         *m_pPVRBackend;
 
-  bool			SupportsChannelSwitch(void) const;
-  void			Close();
+  bool              CloseAndOpenFile(const CURL& url);
+  bool              GetNewChannel(CFileItem& item);
+  bool              SupportsChannelSwitch(void) const;
+  void              Close();
+  bool              PrepareForChannelSwitch(const CPVRChannelPtr &channel);
+  bool              PerformChannelSwitch();
+  CDSPVRBackend*    GetPVRBackend();
 
 public:
   CDSInputStreamPVRManager(CDSPlayer *pPlayer);
   ~CDSInputStreamPVRManager(void);
 
-  bool			Open(const CFileItem& file);
+  bool        Open(const CFileItem& file);
 
-  bool            SelectChannelByNumber(unsigned int iChannel);
-  bool            SelectChannel(const PVR::CPVRChannelPtr &channel);
-  bool            NextChannel(bool preview = false);
-  bool            PrevChannel(bool preview = false);
-  bool			UpdateItem(CFileItem& item);
+  bool        SelectChannelByNumber(unsigned int iChannel);
+  bool        SelectChannel(const PVR::CPVRChannelPtr &channel);
+  bool        NextChannel(bool preview = false);
+  bool        PrevChannel(bool preview = false);
+  bool        UpdateItem(CFileItem& item);
 
-  uint64_t        GetTotalTime();
-  uint64_t        GetTime();
+  uint64_t    GetTotalTime();
+  uint64_t    GetTime();
 };
 
 extern CDSInputStreamPVRManager* g_pPVRStream;

--- a/xbmc/cores/DSPlayer/DSPlayer.cpp
+++ b/xbmc/cores/DSPlayer/DSPlayer.cpp
@@ -628,15 +628,7 @@ void CDSPlayer::Process()
 
   CLog::Log(LOGNOTICE, "%s - Successfully creating DS Graph", __FUNCTION__);
 
-  if (g_pPVRStream)
-  {
-    CFileItem item(g_application.CurrentFileItem());
-    if (g_pPVRStream->UpdateItem(item))
-    {
-      g_application.CurrentFileItem() = item;
-      CApplicationMessenger::Get().SetCurrentItem(item);
-    }
-  }
+  UpdateApplication();
 
   g_dsSettings.pRendererSettings->bAllowFullscreen = m_PlayerOptions.fullscreen;
 
@@ -1031,30 +1023,61 @@ bool CDSPlayer::OnAction(const CAction &action)
     case ACTION_MOVE_UP:
     case ACTION_NEXT_ITEM:
     case ACTION_CHANNEL_UP:
-      SelectChannel(true);
-      g_infoManager.SetDisplayAfterSeek();
-      ShowPVRChannelInfo();
+      if (SelectChannel(true))
+      {
+        g_infoManager.SetDisplayAfterSeek();
+        ShowPVRChannelInfo();
+      }
+      else if (CDSPlayer::PlayerState == DSPLAYER_CLOSED)
+      {
+        m_callback.OnPlayBackStopped();
+      }
+      else
+      {
+        CLog::Log(LOGWARNING, "%s - failed to switch channel. playback stopped", __FUNCTION__);
+        CApplicationMessenger::Get().MediaStop(false);
+      }
       return true;
       break;
 
     case ACTION_MOVE_DOWN:
     case ACTION_PREV_ITEM:
     case ACTION_CHANNEL_DOWN:
-      SelectChannel(false);
-      g_infoManager.SetDisplayAfterSeek();
-      ShowPVRChannelInfo();
+      if (SelectChannel(false))
+      {
+        g_infoManager.SetDisplayAfterSeek();
+        ShowPVRChannelInfo();
+      }
+      else if (CDSPlayer::PlayerState == DSPLAYER_CLOSED)
+      {
+        m_callback.OnPlayBackStopped();
+      }
+      else
+      {
+        CLog::Log(LOGWARNING, "%s - failed to switch channel. playback stopped", __FUNCTION__);
+        CApplicationMessenger::Get().MediaStop(false);
+      }
       return true;
       break;
 
     case ACTION_CHANNEL_SWITCH:
-    {
       // Offset from key codes back to button number
-      int channel = action.GetAmount();
-      SwitchChannel(channel);
-      g_infoManager.SetDisplayAfterSeek();
-      ShowPVRChannelInfo();
+      int channel = (int)action.GetAmount();
+      if (SwitchChannel(channel))
+      {
+        g_infoManager.SetDisplayAfterSeek();
+        ShowPVRChannelInfo();
+      }
+      else if (CDSPlayer::PlayerState == DSPLAYER_CLOSED)
+      {
+        m_callback.OnPlayBackStopped();
+      }
+      else
+      {
+        CLog::Log(LOGWARNING, "%s - failed to switch channel. playback stopped", __FUNCTION__);
+        CApplicationMessenger::Get().MediaStop(false);
+      }
       return true;
-    }
       break;
     }
   }
@@ -1115,6 +1138,41 @@ bool CDSPlayer::SeekTimeRelative(__int64 iTime)
   PostMessage(new CDSMsgPlayerSeekTime(MSEC_TO_DS_TIME((abstime < 0) ? 0 : abstime)));
   m_callback.OnPlayBackSeek((int)abstime, (int)iTime);
   return true;
+}
+
+void CDSPlayer::UpdateApplication()
+{
+  if (g_pPVRStream)
+  {
+    CFileItem item(g_application.CurrentFileItem());
+    if (g_pPVRStream->UpdateItem(item))
+    {
+      g_application.CurrentFileItem() = item;
+      CApplicationMessenger::Get().SetCurrentItem(item);
+    }
+  }
+}
+
+// Called after fast channel switch.
+void CDSPlayer::UpdateChannelSwitchSettings()
+{
+  if (g_dsGraph->GetTime(true) + MSEC_TO_DS_TIME(3000) < g_dsGraph->GetTotalTime(true))
+  {
+    // Pause playback
+    PostMessage(new CDSMsgBool(CDSMsg::PLAYER_PAUSE, true), false);
+    // Seek to the end of timeshift buffer
+    PostMessage(new CDSMsgPlayerSeekTime(g_dsGraph->GetTotalTime(true) - MSEC_TO_DS_TIME(3000)));
+    // Start playback
+    PostMessage(new CDSMsgBool(CDSMsg::PLAYER_PLAY, true), false);
+  }
+
+#ifdef HAS_VIDEO_PLAYBACK
+  // when using fast channel switching some shortcuts are taken which 
+  // means we'll have to update the view mode manually
+  g_renderManager.SetViewMode(CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode);
+#endif
+
+  m_PlayerOptions.identify = false;
 }
 
 bool CDSPlayer::SwitchChannel(unsigned int iChannelNumber)

--- a/xbmc/cores/DSPlayer/DSPlayer.h
+++ b/xbmc/cores/DSPlayer/DSPlayer.h
@@ -242,7 +242,9 @@ public:
 
   void ShowEditionDlg(bool playStart);
   bool OpenFileInternal(const CFileItem& file);
-
+  void UpdateApplication();
+  void UpdateChannelSwitchSettings();
+  
   //madVR Window
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
   static HWND m_hWnd;

--- a/xbmc/cores/DSPlayer/PVR/DSArgusTV.cpp
+++ b/xbmc/cores/DSPlayer/PVR/DSArgusTV.cpp
@@ -1,0 +1,112 @@
+/*
+*      Copyright (C) 2005-2008 Team XBMC
+*      http://www.xbmc.org
+*
+*      Copyright (C) 2015 Romank
+*      https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#ifdef HAS_DS_PLAYER
+
+#include "DSArgusTV.h"
+
+CDSArgusTV::CDSArgusTV(const CStdString& strBackendBaseAddress, const CStdString& strBackendName) : CDSPVRBackend(strBackendBaseAddress, strBackendName)
+{
+  CLog::Log(LOGNOTICE, "%s PVR Backend name: %s, Base Address: %s", __FUNCTION__, strBackendName.c_str(), strBackendBaseAddress.c_str());
+}
+
+CDSArgusTV::~CDSArgusTV(void)
+{
+  CLog::Log(LOGNOTICE, "%s", __FUNCTION__);
+}
+
+bool CDSArgusTV::ConvertStreamURLToTimeShiftFilePath(const CStdString& strUrl, CStdString& strTimeShiftFile)
+{
+  bool bReturn = false;
+
+  if (strUrl.empty())
+  {
+    CLog::Log(LOGERROR, "%s Stream URL is not valid.", __FUNCTION__);
+    return false;
+  }
+
+  if (!SupportsStreamConversion(strUrl))
+  {
+    CLog::Log(LOGERROR, "%s Stream Conversion is not supported.", __FUNCTION__);
+    return false;
+  }
+  
+  strTimeShiftFile.clear() ;
+  CStdString strTimeShiftFilePath;
+  
+  CVariant json_response;
+  bReturn = SendCommandToArgusTV_GET("ArgusTV/Control/GetLiveStreams", json_response);
+  if (bReturn)
+  {	  
+    bReturn = false;
+    if(json_response.isArray())
+    {
+      for (CVariant::const_iterator_array itemItr = json_response.begin_array(); itemItr != json_response.end_array(); itemItr++)
+      {
+        if (!(*itemItr).isObject())
+          continue;
+      
+        if ((*itemItr).isMember("RtspUrl") && (*itemItr)["RtspUrl"].isString() && (*itemItr)["RtspUrl"].asString() == strUrl)
+        {    
+          if ((*itemItr).isMember("TimeshiftFile") && (*itemItr)["TimeshiftFile"].isString())
+          {
+            strTimeShiftFilePath = (*itemItr)["TimeshiftFile"].asString();
+            bReturn = true;
+          }
+        }
+      }
+    }
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s Failed to get Timeshifting info from the backend", __FUNCTION__);
+  }
+
+  if (bReturn)
+    bReturn = IsFileExistAndAccessible(strTimeShiftFilePath);
+  
+  if (bReturn)
+  {
+    CLog::Log(LOGNOTICE, "%s Rtsp Stream: %s converted to Timeshift File Path: %s", __FUNCTION__, strUrl.c_str(), strTimeShiftFilePath.c_str());
+    strTimeShiftFile = strTimeShiftFilePath;
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s Failed to converted Rtsp Stream: %s to Timeshift File Path", __FUNCTION__, strUrl.c_str());
+  }
+
+  return bReturn;
+}
+
+bool CDSArgusTV::SendCommandToArgusTV_GET(const CStdString& strCommand, CVariant &json_response)
+{
+  return JSONRPCSendCommand(REQUEST_GET, strCommand, "", json_response);
+}
+
+bool CDSArgusTV::SendCommandToArgusTV_POST(const CStdString& strCommand, const CStdString& strArguments, CVariant &json_response)
+{
+  return JSONRPCSendCommand(REQUEST_POST, strCommand, strArguments, json_response);
+}
+
+#endif

--- a/xbmc/cores/DSPlayer/PVR/DSArgusTV.h
+++ b/xbmc/cores/DSPlayer/PVR/DSArgusTV.h
@@ -1,0 +1,45 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2008 Team XBMC
+*      http://www.xbmc.org
+*
+*      Copyright (C) 2015 Romank
+*      https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+
+#ifndef HAS_DS_PLAYER
+#error DSPlayer's header file included without HAS_DS_PLAYER defined
+#endif
+
+#include "DSPVRBackend.h"
+
+class CDSArgusTV : public CDSPVRBackend
+{
+public:
+  CDSArgusTV(const CStdString& strBackendBaseAddress, const CStdString& strBackendName);
+  virtual ~CDSArgusTV();
+  virtual bool        ConvertStreamURLToTimeShiftFilePath(const CStdString& strUrl, CStdString& strTimeShiftFile);
+  virtual bool        SupportsStreamConversion(const CStdString& strUrl) const { return ((strUrl.Left(7)).Equals("rtsp://", true)); };
+  virtual bool        SupportsFastChannelSwitch() const { return true; };
+
+private:          
+  bool                SendCommandToArgusTV_GET(const CStdString& strCommand, CVariant &json_response);
+  bool                SendCommandToArgusTV_POST(const CStdString& strCommand, const CStdString& strArguments, CVariant &json_response);
+};

--- a/xbmc/cores/DSPlayer/PVR/DSMediaPortal.cpp
+++ b/xbmc/cores/DSPlayer/PVR/DSMediaPortal.cpp
@@ -1,0 +1,303 @@
+/*
+*      Copyright (C) 2005-2008 Team XBMC
+*      http://www.xbmc.org
+*
+*      Copyright (C) 2015 Romank
+*      https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+
+#ifdef HAS_DS_PLAYER
+
+#include "DSMediaPortal.h"
+
+CDSMediaPortal::CDSMediaPortal(const CStdString& strBackendBaseAddress, const CStdString& strBackendName) : CDSPVRBackend(strBackendBaseAddress, strBackendName)
+{
+  CLog::Log(LOGNOTICE, "%s PVR Backend name: %s, Base Address: %s", __FUNCTION__, strBackendName.c_str(), strBackendBaseAddress.c_str());
+}
+
+CDSMediaPortal::~CDSMediaPortal(void)
+{
+  CLog::Log(LOGNOTICE, "%s", __FUNCTION__);
+}
+
+bool CDSMediaPortal::ConvertStreamURLToTimeShiftFilePath(const CStdString& strUrl, CStdString& strTimeShiftFile)
+{
+  bool bReturn = false;
+  CStdString strResponse;
+  strTimeShiftFile.clear();
+  CStdString strTimeShiftFilePath;
+  CStdString strResolvedUrl;
+
+  if (strUrl.empty())
+  {
+    CLog::Log(LOGERROR, "%s Stream URL is not valid.", __FUNCTION__);
+    return false;
+  }
+
+  if (!SupportsStreamConversion(strUrl))
+  {
+    CLog::Log(LOGERROR, "%s Stream Conversion is not supported.", __FUNCTION__);
+    return false;
+  }
+
+  // Try to resolve url
+  if (!ResolveHostName(strUrl, strResolvedUrl))
+    strResolvedUrl = strUrl;
+
+  // Try to get timeshift file, if failed - try to find pvr.mediaportal.tvserver 
+  // addon user name and get timeshift info again.
+  bReturn = ConvertRtspStreamUrlToTimeShiftFilePath(strResolvedUrl, strTimeShiftFilePath);
+  if (!bReturn)
+  {
+    // Find pvr.mediaportal.tvserver addon user name
+    bReturn = SendCommandToMPTVServer("GetUserName:TimeshiftingUsers\n", strResponse);
+    if (bReturn)
+    {
+      // Find TimeShift file path
+      std::vector<std::string> timeshiftingUserNames;
+      StringUtils::Tokenize(strResponse, timeshiftingUserNames, ",");
+      bReturn = false;
+      for (unsigned int i = 0; i < timeshiftingUserNames.size(); i++)
+      {
+        if (SendCommandToMPTVServer("SetUserName:" + timeshiftingUserNames[i] + "\n", strResponse))
+        {
+          if (ConvertRtspStreamUrlToTimeShiftFilePath(strResolvedUrl, strTimeShiftFilePath))
+          {
+            strTimeShiftFile = strTimeShiftFilePath;
+            CLog::Log(LOGNOTICE, "%s MediaPortal TVServer user name found: %s ", __FUNCTION__, timeshiftingUserNames[i].c_str());
+            bReturn = true;
+            break;
+          }
+        }
+        else
+        {
+          CLog::Log(LOGERROR, "%s Failed to MediaPortal TVServer failed to Set User Name: %s", __FUNCTION__, timeshiftingUserNames[i].c_str());
+          break;
+        }
+      }
+    }
+    else
+    {
+      CLog::Log(LOGERROR, "%s Failed to get Timeshifting User names from MediaPortal TVServer.", __FUNCTION__);
+    }
+  }
+
+  if (bReturn)
+    bReturn = IsFileExistAndAccessible(strTimeShiftFilePath);
+
+  if (bReturn)
+  {
+    CLog::Log(LOGNOTICE, "%s Rtsp Stream: %s converted to Timeshift File Path: %s", __FUNCTION__, strUrl.c_str(), strTimeShiftFilePath.c_str());
+    strTimeShiftFile = strTimeShiftFilePath;
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s Failed to converted Rtsp Stream: %s to Timeshift File Path", __FUNCTION__, strUrl.c_str());
+  }
+  
+  return bReturn;
+}
+
+bool  CDSMediaPortal::GetRecordingStreamURL(const CStdString& strRecordingId, CStdString& strRecordingUrl, bool bGetUNCPath /* = false */)
+{
+  bool bReturn = false;
+  CStdString strResponse;
+  CStdString strRecUrl;
+  strRecordingUrl.clear();
+
+  if (strRecordingId.empty())
+  {
+    CLog::Log(LOGERROR, "%s Recording Id is not valid.", __FUNCTION__);
+    return false;
+  }
+
+  // GetRecordingInfo with RTSP url  (TVServerXBMC v1.1.0.90 or higher)
+  bReturn = SendCommandToMPTVServer("GetRecordingInfo:" + strRecordingId + "|True\n", strResponse);
+  CLog::Log(LOGDEBUG, "%s Response message: %s", __FUNCTION__, strResponse.c_str());
+  /*
+   * TVServerXBMC serverinterface.cs
+   * XBMC pvr side:
+   * index, channelname, lifetime, priority, start time, duration
+   * title, subtitle, description, stream_url, directory
+   *
+   * [0] index / mediaportal recording id
+   * [1] start time
+   * [2] end time
+   * [3] channel name
+   * [4] title
+   * [5] description
+   * [6] stream_url (resolved hostname if resolveHostnames = True)
+   * [7] filename (we can bypass rtsp streaming when XBMC and the TV server are on the same machine)
+   * [8] lifetime (mediaportal keep until?)
+   * [9] original unresolved stream_url if resolveHostnames = True, otherwise this field is missing
+  */
+  if (bReturn && !strResponse.empty() && strResponse.find("[ERROR]") == std::string::npos)
+  {
+    bReturn = false;
+    // Make sure that the empty fields will not be ignored by "Tokenize" function.
+    strResponse.Replace("||", "|_|");
+    std::vector<std::string> recordingInfo;
+    StringUtils::Tokenize(strResponse, recordingInfo, "|");
+    if (recordingInfo.size() >= 8)
+    {
+      if (bGetUNCPath)
+      {    
+        // Recording UNC Path 
+        strRecUrl = recordingInfo[7];
+        if (CURL::IsFullPath(strRecUrl) && IsFileExistAndAccessible(strRecUrl))
+          bReturn = true;
+      }
+      else
+      {
+        // Recording RTSP url 
+        strRecUrl = recordingInfo[6]; 
+        if (URIUtils::IsInternetStream(strRecUrl))
+        {
+          CStdString strResolvedRecUrl;
+          if (ResolveHostName(strRecUrl, strResolvedRecUrl))
+            strRecUrl = strResolvedRecUrl;
+          bReturn = true;
+        }
+      }
+    } 
+    else
+    {
+      CLog::Log(LOGDEBUG, "%s PVR Backend response message is invalid.", __FUNCTION__);
+    }
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s Failed to get recording info from PVR Backend, recording id: %s", __FUNCTION__, strRecordingId.c_str());
+  }
+
+  if (bReturn)
+  {
+    CLog::Log(LOGNOTICE, "%s Recording Stream URL: %s", __FUNCTION__, strRecUrl.c_str());
+    strRecordingUrl = strRecUrl;
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s Failed to get recording stream URL from PVR Backend.", __FUNCTION__);
+  }
+
+  return bReturn;
+}
+
+bool CDSMediaPortal::SendCommandToMPTVServer(const CStdString& strCommand, CStdString & strResponse)
+{
+  bool bReturn = true;
+  strResponse.clear();
+  CStdString strResponseMessage;
+
+  if (!TCPClientIsConnected())
+    bReturn = ConnectToMPTVServer();
+    
+  if (bReturn)
+    bReturn = TCPClientSendCommand(strCommand, strResponseMessage);
+
+  if (bReturn)
+    strResponse = strResponseMessage;
+  
+  return bReturn;
+}
+
+bool CDSMediaPortal::ConnectToMPTVServer()
+{ 
+  bool bReturn = false;
+  CStdString strResponseMessage;
+  
+  bReturn = TCPClientConnect();
+  if (bReturn)
+  {
+    // Send connect message to mp tvserver
+    bReturn = TCPClientSendCommand("PVRclientXBMC:0-1\n", strResponseMessage);
+    if (bReturn)
+    {      
+      if (strResponseMessage.length() == 0)
+        bReturn = false;
+      
+      if (bReturn && strResponseMessage.find("Unexpected protocol") != std::string::npos)
+      {
+        CLog::Log(LOGERROR, "%s TVServer does not accept protocol: PVRclientXBMC:0-1", __FUNCTION__);
+        bReturn = false;
+      }
+    }
+  }
+  
+  if (!bReturn)
+    CLog::Log(LOGERROR, "%s Failed to connect to MediaPortal TVServer!", __FUNCTION__);
+
+  return bReturn;
+}
+
+bool CDSMediaPortal::ConvertRtspStreamUrlToTimeShiftFilePath(const CStdString& strUrl, CStdString& strTimeShiftFile)
+{
+  /*
+  "True|rtsp://HostName:554/stream5.2|\\\\HOSTNAME-PC\\Timeshift\\live5-2.ts.tsbuffer|ChannelInfo" - new version contains UNC timeshift path
+  "True|rtsp://HostName:554/stream5.2|ChannelInfo"                                                 - old version without UNC timeshift path
+  */
+
+  bool bReturn = false;
+  strTimeShiftFile.clear();
+  CStdString strResponse;
+  CStdString strRtspUrl;
+  CStdString strResolvedRtspUrl;
+
+  bReturn = SendCommandToMPTVServer("IsTimeshifting:\n", strResponse);
+  if (bReturn && strResponse.find("True") != std::string::npos)
+  {
+    // Find TimeShift file path
+    std::vector<std::string> tokens;
+    StringUtils::Tokenize(strResponse, tokens, "|");
+    bReturn = false;
+        
+    if (tokens.size() > 2 && tokens[0] == "True" )
+    {
+      strRtspUrl = tokens[1];
+      // From TVServerKodi: 
+      // "Workaround for MP TVserver bug when using default port for rtsp => returns rtsp://ip:0"
+      strRtspUrl.Replace(":554", "");
+      strRtspUrl.Replace(":0", "");
+
+      if (!ResolveHostName(strRtspUrl, strResolvedRtspUrl))
+        strResolvedRtspUrl = "";
+      
+      if (strRtspUrl == strUrl || strResolvedRtspUrl == strUrl)
+      {
+        if (tokens[2].find(".ts.tsbuffer") != std::string::npos)
+        {
+          strTimeShiftFile = tokens[2];
+          bReturn = true;
+        }
+      }
+    }
+  }
+  else
+  {
+    bReturn = false;
+    CLog::Log(LOGWARNING, "%s Failed to get Timeshifting info from the MediaPortal TVServer", __FUNCTION__);
+  }
+  if (bReturn)
+    CLog::Log(LOGNOTICE, "%s Timeshift File found: %s", __FUNCTION__, strTimeShiftFile.c_str());
+
+  return bReturn;
+}
+
+#endif

--- a/xbmc/cores/DSPlayer/PVR/DSMediaPortal.h
+++ b/xbmc/cores/DSPlayer/PVR/DSMediaPortal.h
@@ -1,0 +1,47 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2008 Team XBMC
+*      http://www.xbmc.org
+*
+*      Copyright (C) 2015 Romank
+*      https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+
+#ifndef HAS_DS_PLAYER
+#error DSPlayer's header file included without HAS_DS_PLAYER defined
+#endif
+
+#include "DSPVRBackend.h"
+
+class CDSMediaPortal : public CDSPVRBackend
+{
+public:
+  CDSMediaPortal(const CStdString& strBackendBaseAddress, const CStdString& strBackendName);
+  virtual ~CDSMediaPortal();
+  virtual bool        ConvertStreamURLToTimeShiftFilePath(const CStdString& strUrl, CStdString& strTimeShiftFile);
+  virtual bool        SupportsStreamConversion(const CStdString& strUrl) const { return true; };
+  virtual bool        SupportsFastChannelSwitch() const { return true; };
+  virtual bool        GetRecordingStreamURL(const CStdString& strRecordingId, CStdString& strRecordingUrl, bool bGetUNCPath = false);
+
+private:
+  bool                SendCommandToMPTVServer(const CStdString& strCommand, CStdString & strResponse);
+  bool                ConnectToMPTVServer();
+  bool                ConvertRtspStreamUrlToTimeShiftFilePath(const CStdString& strUrl, CStdString& strTimeShiftFile);
+};

--- a/xbmc/cores/DSPlayer/PVR/DSPVRBackend.cpp
+++ b/xbmc/cores/DSPlayer/PVR/DSPVRBackend.cpp
@@ -1,0 +1,317 @@
+/*
+*      Copyright (C) 2005-2008 Team XBMC
+*      http://www.xbmc.org
+*
+*      Copyright (C) 2015 Romank
+*      https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+
+#ifdef HAS_DS_PLAYER
+
+#include "DSPVRBackend.h"
+
+CDSPVRBackend::CDSPVRBackend(const CStdString& strBackendBaseAddress, const CStdString& strBackendName)
+  : m_strBaseURL(strBackendBaseAddress)
+  , m_strBackendName(strBackendName)
+  , m_tcpclient(NULL) 
+{ 
+  if (m_strBaseURL.length() > 7 && !(m_strBaseURL.Left(7).Equals("http://", false)))
+    m_strBaseURL = "http://" + m_strBaseURL;
+}
+
+CDSPVRBackend::~CDSPVRBackend()
+{
+  TCPClientDisconnect();
+  SAFE_DELETE(m_tcpclient);
+}
+
+bool CDSPVRBackend::JSONRPCSendCommand(HttpRequestMethod requestType, const CStdString& strCommand, const CStdString& strArguments, CVariant &json_response)
+{
+  CStdString strResponse;
+  bool bReturn = false;
+
+  switch (requestType)
+  {
+  case REQUEST_GET:
+    bReturn = HttpRequestGET(strCommand, strResponse);
+    break;
+  case REQUEST_POST:
+    bReturn = HttpRequestPOST(strCommand, strArguments, strResponse);
+    break;
+  default:
+   return false;
+  }
+
+  if (bReturn)
+  {
+#ifdef _DEBUG
+    // Print only the first 512 bytes, otherwise XBMC will crash...
+	CLog::Log(LOGDEBUG, "%s Response: %s", __FUNCTION__, strResponse.substr(0, 512).c_str());
+#endif
+    if (strResponse.length() != 0)
+	{
+	  json_response = CJSONVariantParser::Parse(reinterpret_cast<const unsigned char*>(strResponse.c_str()), strResponse.size());
+	  if (json_response.isNull())
+	  {
+		CLog::Log(LOGDEBUG, "%s Failed to parse %s:", __FUNCTION__, strResponse.c_str());
+		return false;
+	  }
+	}
+	else
+	{
+	  CLog::Log(LOGDEBUG, "%s Empty response", __FUNCTION__);
+	  return false;
+    }
+#ifdef _DEBUG
+	  //printValueTree(stdout, json_response);
+#endif
+  }
+
+  return bReturn;
+}
+
+bool CDSPVRBackend::TCPClientConnect()
+{
+  bool bReturn = false;
+
+  if (m_strBaseURL.empty())
+  {
+    CLog::Log(LOGERROR, "%s Base URL is not valid.", __FUNCTION__);
+    return false;
+  }
+
+  if (!m_tcpclient)
+  {
+    m_tcpclient = new CDSSocket(af_inet, pf_inet, sock_stream, tcp);
+  }
+  
+  if (!m_tcpclient->create())
+  {
+    CLog::Log(LOGERROR, "%s Could not connect create socket", __FUNCTION__);
+    return false;
+  }
+
+  const CURL pathToUrl(m_strBaseURL);
+  if (!m_tcpclient->connect(pathToUrl.GetHostName(), (unsigned short)pathToUrl.GetPort()))
+  {
+    CLog::Log(LOGERROR, "%s Could not connect to PVR Backend server", __FUNCTION__);
+    return false;
+  }
+
+  m_tcpclient->set_non_blocking(1);
+  CLog::Log(LOGINFO, "%s Connected to %s", __FUNCTION__, m_strBaseURL.c_str());
+  
+  return m_tcpclient->is_valid();
+}
+
+bool CDSPVRBackend::TCPClientDisconnect()
+{
+  if (!m_tcpclient)
+    return false;
+
+  CLog::Log(LOGINFO, "%s TCP Client Disconnect", __FUNCTION__);
+  return m_tcpclient->close();
+}
+
+bool CDSPVRBackend::TCPClientSendCommand(const CStdString& strCommand, CStdString& strResponse)
+{
+  CSingleLock lock(m_ObjectLock);
+
+  if (!m_tcpclient)
+    return false;
+
+  CStdString strCommandCopy = strCommand;
+  strCommandCopy.Replace("\n","");
+  CLog::Log(LOGDEBUG, "%s Sending Command: '%s'", __FUNCTION__, strCommandCopy.c_str());
+
+  strResponse.clear();
+  if (!m_tcpclient->send(strCommand))
+  {
+    CLog::Log(LOGERROR, "%s Send Command '%s' failed.", __FUNCTION__, strCommandCopy.c_str());
+    return false;
+  }
+
+  string strResult;
+  if (!m_tcpclient->ReadLine(strResult))
+  {
+    CLog::Log(LOGERROR, "%s Send Command - Failed.", __FUNCTION__);
+    return false;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s Response from PVR Backend:'%s'", __FUNCTION__, strResult.c_str());
+
+  strResponse = strResult;
+  return true;
+}
+
+/*
+* Check whether we still have a connection with the Backend Server.
+* return True when a connection is available, otherwise False.
+*/
+bool CDSPVRBackend::TCPClientIsConnected()
+{
+  if (!m_tcpclient || !m_tcpclient->is_valid())
+    return false;
+
+  return true;
+}
+
+bool CDSPVRBackend::IsFileExistAndAccessible(const CStdString& strFilePath)
+{
+  long errCode;
+
+  // Check if we can access the file
+  bool bReturn = CDSFile::Exists(strFilePath, &errCode);
+  if (!bReturn)
+  {
+    switch(errCode)
+    {
+      case ERROR_FILE_NOT_FOUND:
+        CLog::Log(LOGERROR, "%s File not found: %s.", __FUNCTION__, strFilePath.c_str());
+        break;
+      case ERROR_ACCESS_DENIED:
+      {
+        char strUserName[256];
+        DWORD lLength = 256;
+
+        if (GetUserName(strUserName, &lLength))
+          CLog::Log(LOGERROR, "%s Access denied on %s. Check share access rights for user '%s'.\n", __FUNCTION__, strFilePath.c_str(), strUserName);
+        else
+          CLog::Log(LOGERROR, "%s Access denied on %s. Check share access rights.", __FUNCTION__, strFilePath.c_str());
+        
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, "DSPlayer", "Access denied: " + strFilePath, TOAST_DISPLAY_TIME, false);
+        break;
+      }
+      default:
+        CLog::Log(LOGERROR, "%s Cannot find or access file: %s. Check share access rights.", __FUNCTION__, strFilePath.c_str());
+    }
+  }
+  else
+  {
+    CLog::Log(LOGDEBUG, "%s File found: %s", __FUNCTION__, strFilePath.c_str());
+  }
+
+  return bReturn;
+}
+
+bool CDSPVRBackend::ResolveHostName(const CStdString& strUrl, CStdString& strResolvedUrl)
+{
+  bool bReturn = false;
+  strResolvedUrl.clear();
+
+  CURL url(strUrl);
+  CStdString strHostName = url.GetHostName();
+  hostent* remoteHost = gethostbyname(strHostName.c_str());
+  if (remoteHost != NULL)
+  {
+    in_addr * address = (in_addr *)remoteHost->h_addr;
+    CStdString ip_address = inet_ntoa(*address);
+    strResolvedUrl = strUrl;
+    if (ip_address != strHostName)
+    {
+      strResolvedUrl.Replace(strHostName, ip_address);
+      CLog::Log(LOGDEBUG, "%s Successfully resolved host name: %s to ip: %s", __FUNCTION__, strHostName.c_str(), ip_address.c_str());
+    }
+    bReturn = true;
+  }
+
+  if (!bReturn)
+    CLog::Log(LOGERROR, "%s Failed to resolve hostname: %s", __FUNCTION__, strHostName.c_str());
+
+  return bReturn;
+}
+
+bool CDSPVRBackend::HttpRequestGET(const CStdString& strCommand, CStdString& strResponse)
+{
+  if (m_strBaseURL.empty())
+  {
+    CLog::Log(LOGERROR, "%s Base URL is not valid.", __FUNCTION__);
+    return false;
+  }
+
+  CSingleLock lock(m_ObjectLock);
+
+  bool bReturn = false;
+  CStdString strUrl = m_strBaseURL + strCommand;
+  CLog::Log(LOGDEBUG, "%s URL: %s", __FUNCTION__, strUrl.c_str());
+  CFile file;
+  if (file.Open(strUrl.c_str(), 0))
+  {
+    char buffer[1024];
+    while (file.ReadString(buffer, 1024))
+      strResponse.append(buffer);
+    bReturn = true;
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s Can not open url: %s", __FUNCTION__, strUrl.c_str());
+  }
+
+  file.Close();
+
+  if (!bReturn)
+    CLog::Log(LOGERROR, "%s Request failed, url:", __FUNCTION__, strUrl.c_str());
+  
+  return bReturn;
+}
+
+bool CDSPVRBackend::HttpRequestPOST(const CStdString& strCommand, const CStdString& strArguments, CStdString& strResponse)
+{
+  if (m_strBaseURL.empty())
+  {
+    CLog::Log(LOGERROR, "%s Base URL is not valid.", __FUNCTION__);
+    return false;
+  }
+
+  CSingleLock lock(m_ObjectLock);
+  
+  bool bReturn = false;
+  CStdString strUrl = m_strBaseURL + strCommand;
+  CLog::Log(LOGDEBUG, "%s URL: %s", __FUNCTION__, strUrl.c_str());
+  CFile file;
+  if (file.OpenForWrite(strUrl, false))
+  {
+	  int rc = file.Write(strArguments.c_str(), strArguments.length());
+  	if (rc >= 0)
+  	{
+  	  CStdString result;
+  	  result.clear();
+  	  char buffer[1024];
+	    while (file.ReadString(buffer, 1023))
+  	    result.append(buffer);
+      strResponse = result;
+  	  bReturn = true;
+  	}
+    else
+    {
+      CLog::Log(LOGERROR, "%s Can not write to %s", __FUNCTION__, strUrl.c_str());
+    }
+
+	  file.Close();
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s Can not open %s for write", __FUNCTION__, strUrl.c_str());
+  }
+
+  return bReturn;
+}
+
+#endif

--- a/xbmc/cores/DSPlayer/PVR/DSPVRBackend.h
+++ b/xbmc/cores/DSPlayer/PVR/DSPVRBackend.h
@@ -1,0 +1,85 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2008 Team XBMC
+*      http://www.xbmc.org
+*
+*      Copyright (C) 2015 Romank
+*      https://github.com/Romank1
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#ifndef HAS_DS_PLAYER
+#error DSPlayer's header file included without HAS_DS_PLAYER defined
+#endif
+
+#include "utils/log.h"
+#include "filesystem\File.h"
+#include "threads/CriticalSection.h"
+#include "utils/JSONVariantParser.h"
+#include "utils/StringUtils.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "utils/DSFileUtils.h"
+#include "pvr/PVRManager.h"
+#include "DSSocket.h"
+#include "URL.h"
+#include "utils/URIUtils.h"
+
+using XFILE::CFile;
+
+/* Http Request Method type*/
+enum HttpRequestMethod {
+    REQUEST_GET,
+    REQUEST_POST
+};
+
+#ifdef TARGET_WINDOWS // disable 4355: 'this' used in base member initializer list
+#pragma warning(push)
+#pragma warning(disable: 4355)
+#endif
+
+class CDSPVRBackend
+{
+public:
+  CDSPVRBackend(const CStdString& strBackendBaseAddress, const CStdString& strBackendName);
+  virtual ~CDSPVRBackend();
+  virtual bool        ConvertStreamURLToTimeShiftFilePath(const CStdString& strUrl, CStdString& strTimeShiftFile) = 0;
+  virtual bool        SupportsStreamConversion(const CStdString& strUrl) const = 0;
+  virtual bool        SupportsFastChannelSwitch() const = 0;
+  virtual bool        GetRecordingStreamURL(const CStdString& strRecordingId, CStdString& strRecordingUrl, bool bGetUNCPath) { return false; };
+  
+  const CStdString&   GetBackendName() const { return m_strBackendName; };
+
+protected:
+  bool                JSONRPCSendCommand(HttpRequestMethod requestType, const CStdString& strCommand, const CStdString& strArguments, CVariant &json_response);
+  bool                TCPClientIsConnected();
+  bool                TCPClientConnect();
+  bool                TCPClientDisconnect();
+  bool                TCPClientSendCommand(const CStdString& strCommand, CStdString & strResponse);
+  bool                IsFileExistAndAccessible(const CStdString& strFilePath);
+  bool                ResolveHostName(const CStdString& strUrl, CStdString& strResolvedUrl);
+                    
+private:              
+  bool                HttpRequestGET(const CStdString& strCommand, CStdString& strResponse);
+  bool                HttpRequestPOST(const CStdString& strCommand, const CStdString& strArguments, CStdString& strResponse);
+  
+  CStdString          m_strBaseURL;
+  CStdString          m_strBackendName;
+  CDSSocket          *m_tcpclient;
+  CCriticalSection    m_ObjectLock;
+};
+

--- a/xbmc/cores/DSPlayer/PVR/DSSocket.cpp
+++ b/xbmc/cores/DSPlayer/PVR/DSSocket.cpp
@@ -1,0 +1,602 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAS_DS_PLAYER
+
+#include "DSSocket.h"
+#include "utils/log.h"
+
+using namespace std;
+
+/* Master defines for client control */
+#define RECEIVE_TIMEOUT 6 //sec
+
+CDSSocket::CDSSocket(const enum SocketFamily family, const enum SocketDomain domain, const enum SocketType type, const enum SocketProtocol protocol)
+{
+  _sd = INVALID_SOCKET;
+  _family = family;
+  _domain = domain;
+  _type = type;
+  _protocol = protocol;
+  memset (&_sockaddr, 0, sizeof( _sockaddr ) );
+}
+
+
+CDSSocket::CDSSocket()
+{
+  // Default constructor, default settings
+  _sd = INVALID_SOCKET;
+  _family = af_inet;
+  _domain = pf_inet;
+  _type = sock_stream;
+  _protocol = tcp;
+  memset (&_sockaddr, 0, sizeof( _sockaddr ) );
+}
+
+
+CDSSocket::~CDSSocket()
+{
+  close();
+}
+
+bool CDSSocket::setHostname(const std::string& host)
+{
+  if (isalpha(host.c_str()[0]))
+  {
+    // host address is a name
+    struct hostent *he = NULL;
+    if ((he = gethostbyname( host.c_str() )) == 0)
+    {
+      errormessage( getLastError(), "Socket::setHostname");
+      return false;
+    }
+
+    _sockaddr.sin_addr = *((in_addr *) he->h_addr);
+  }
+  else
+  {
+    _sockaddr.sin_addr.s_addr = inet_addr(host.c_str());
+  }
+  return true;
+}
+
+bool CDSSocket::close()
+{
+  if (is_valid())
+  {
+    if (_sd != SOCKET_ERROR)
+#ifdef TARGET_WINDOWS
+      closesocket(_sd);
+#else
+      ::close(_sd);
+#endif
+    _sd = INVALID_SOCKET;
+    osCleanup();
+    return true;
+  }
+  return false;
+}
+
+bool CDSSocket::create()
+{
+  if( is_valid() )
+  {
+    close();
+  }
+
+  if(!osInit())
+  {
+    return false;
+  }
+
+  _sd = socket(_family, _type, _protocol );
+  //0 indicates that the default protocol for the type selected is to be used.
+  //For example, IPPROTO_TCP is chosen for the protocol if the type  was set to
+  //SOCK_STREAM and the address family is AF_INET.
+
+  if (_sd == INVALID_SOCKET)
+  {
+    errormessage( getLastError(), "Socket::create" );
+    return false;
+  }
+
+  return true;
+}
+
+
+bool CDSSocket::bind(const unsigned short port)
+{
+
+  if (!is_valid())
+  {
+    return false;
+  }
+
+  _sockaddr.sin_family = (sa_family_t) _family;
+  _sockaddr.sin_addr.s_addr = INADDR_ANY;  //listen to all
+  _sockaddr.sin_port = htons( port );
+
+  int bind_return = ::bind(_sd, (sockaddr*)(&_sockaddr), sizeof(_sockaddr));
+
+  if ( bind_return == -1 )
+  {
+    errormessage( getLastError(), "Socket::bind" );
+    return false;
+  }
+
+  return true;
+}
+
+
+bool CDSSocket::listen() const
+{
+
+  if (!is_valid())
+  {
+    return false;
+  }
+
+  int listen_return = ::listen (_sd, SOMAXCONN);
+  //This is defined as 5 in winsock.h, and 0x7FFFFFFF in winsock2.h.
+  //linux 128//MAXCONNECTIONS =1
+
+  if (listen_return == -1)
+  {
+    errormessage( getLastError(), "Socket::listen" );
+    return false;
+  }
+
+  return true;
+}
+
+
+bool CDSSocket::accept(CDSSocket& new_socket) const
+{
+  if (!is_valid())
+  {
+    return false;
+  }
+
+  socklen_t addr_length = sizeof( _sockaddr );
+  new_socket._sd = ::accept(_sd, const_cast<sockaddr*>( (const sockaddr*) &_sockaddr), &addr_length );
+
+  if (new_socket._sd == INVALID_SOCKET)
+  {
+    errormessage( getLastError(), "Socket::accept" );
+    return false;
+  }
+
+  return true;
+}
+
+
+int CDSSocket::send(const std::string& data)
+{
+  return CDSSocket::send((const char*)data.c_str(), (const unsigned int)data.size());
+}
+
+
+int CDSSocket::send(const char* data, const unsigned int len)
+{
+  fd_set set_w, set_e;
+  struct timeval tv;
+  int  result;
+
+  if (!is_valid())
+  {
+    return 0;
+  }
+
+  // fill with new data
+  tv.tv_sec  = 0;
+  tv.tv_usec = 0;
+
+  FD_ZERO(&set_w);
+  FD_ZERO(&set_e);
+  FD_SET(_sd, &set_w);
+  FD_SET(_sd, &set_e);
+
+  result = select(FD_SETSIZE, &set_w, NULL, &set_e, &tv);
+
+  if (result < 0)
+  {
+    CLog::Log(LOGERROR, "%s Socket::send  - select failed", __FUNCTION__);
+    _sd = INVALID_SOCKET;
+    return 0;
+  }
+  if (FD_ISSET(_sd, &set_w))
+  {
+    CLog::Log(LOGERROR, "%s Socket::send  - failed to send data", __FUNCTION__);
+    _sd = INVALID_SOCKET;
+    return 0;
+  }
+
+  int status = ::send(_sd, data, len, 0 );
+
+  if (status == -1)
+  {
+    errormessage( getLastError(), "Socket::send");
+    CLog::Log(LOGERROR, "%s Socket::send  - failed to send data", __FUNCTION__);
+    _sd = INVALID_SOCKET;
+    return 0;
+  }
+  return status;
+}
+
+
+int CDSSocket::sendto(const char* data, unsigned int size, bool sendcompletebuffer)
+{
+  int sentbytes = 0;
+  int i;
+
+  do
+  {
+    i = ::sendto(_sd, data, size, 0, (const struct sockaddr*) &_sockaddr, sizeof( _sockaddr ) );
+
+    if (i <= 0)
+    {
+      errormessage( getLastError(), "Socket::sendto");
+      osCleanup();
+      return i;
+    }
+    sentbytes += i;
+  } while ( (sentbytes < (int) size) && (sendcompletebuffer == true));
+
+  return i;
+}
+
+
+int CDSSocket::receive(std::string& data, unsigned int minpacketsize) const
+{
+  char * buf = NULL;
+  int status = 0;
+
+  if (!is_valid())
+  {
+    return 0;
+  }
+
+  buf = new char [ minpacketsize + 1 ];
+  memset ( buf, 0, minpacketsize + 1 );
+
+  status = receive( buf, minpacketsize, minpacketsize );
+
+  data = buf;
+
+  delete[] buf;
+  return status;
+}
+
+
+//Receive until error or \n
+bool CDSSocket::ReadLine(string& line)
+{
+  fd_set         set_r, set_e;
+  timeval        timeout;
+  int            retries = 6;
+  char           buffer[2048];
+
+  if (!is_valid())
+    return false;
+
+  while (true)
+  {
+    size_t pos1 = line.find("\r\n", 0);
+    if (pos1 != std::string::npos)
+    {
+      line.erase(pos1, string::npos);
+      return true;
+    }
+
+    timeout.tv_sec  = RECEIVE_TIMEOUT;
+    timeout.tv_usec = 0;
+
+    // fill with new data
+    FD_ZERO(&set_r);
+    FD_ZERO(&set_e);
+    FD_SET(_sd, &set_r);
+    FD_SET(_sd, &set_e);
+    int result = select(FD_SETSIZE, &set_r, NULL, &set_e, &timeout);
+
+    if (result < 0)
+    {
+      CLog::Log(LOGDEBUG, "%s select failed", __FUNCTION__);
+      errormessage(getLastError(), __FUNCTION__);
+      _sd = INVALID_SOCKET;
+      return false;
+    }
+
+    if (result == 0)
+    {
+      if (retries != 0)
+      {
+         CLog::Log(LOGDEBUG, "%s timeout waiting for response, retrying... (%i)", __FUNCTION__, retries);
+         retries--;
+        continue;
+      } else {
+         CLog::Log(LOGDEBUG, "%s timeout waiting for response. Aborting after 10 retries.", __FUNCTION__);
+         return false;
+      }
+    }
+
+    result = recv(_sd, buffer, sizeof(buffer) - 1, 0);
+    if (result < 0)
+    {
+      CLog::Log(LOGDEBUG, "%s recv failed", __FUNCTION__);
+      errormessage(getLastError(), __FUNCTION__);
+      _sd = INVALID_SOCKET;
+      return false;
+    }
+    buffer[result] = 0;
+
+    line.append(buffer);
+  }
+
+  return true;
+}
+
+
+int CDSSocket::receive(std::string& data) const
+{
+  char buf[MAXRECV + 1];
+  int status = 0;
+
+  if ( !is_valid() )
+  {
+    return 0;
+  }
+
+  memset ( buf, 0, MAXRECV + 1 );
+  status = receive( buf, MAXRECV, 0 );
+  data = buf;
+
+  return status;
+}
+
+int CDSSocket::receive(char* data, const unsigned int buffersize, const unsigned int minpacketsize) const
+{
+  unsigned int receivedsize = 0;
+
+  if ( !is_valid() )
+  {
+    return 0;
+  }
+
+  while ( (receivedsize <= minpacketsize) && (receivedsize < buffersize) )
+  {
+    int status = ::recv(_sd, data+receivedsize, (buffersize - receivedsize), 0 );
+
+    if ( status == SOCKET_ERROR )
+    {
+      errormessage( getLastError(), "Socket::receive" );
+      return status;
+    }
+
+    receivedsize += status;
+  }
+
+  return receivedsize;
+}
+
+
+int CDSSocket::recvfrom(char* data, const int buffersize, struct sockaddr* from, socklen_t* fromlen) const
+{
+  int status = ::recvfrom(_sd, data, buffersize, 0, from, fromlen);
+
+  return status;
+}
+
+
+bool CDSSocket::connect(const std::string& host, const unsigned short port)
+{
+  if ( !is_valid() )
+  {
+    return false;
+  }
+
+  _sockaddr.sin_family = (sa_family_t) _family;
+  _sockaddr.sin_port = htons ( port );
+
+  if ( !setHostname( host ) )
+  {
+    CLog::Log(LOGERROR, "%s Socket::setHostname(%s) failed.", __FUNCTION__, host.c_str());
+    return false;
+  }
+
+  int status = ::connect ( _sd, reinterpret_cast<sockaddr*>(&_sockaddr), sizeof ( _sockaddr ) );
+
+  if ( status == SOCKET_ERROR )
+  {
+    CLog::Log(LOGERROR, "%s Socket::connect %s:%u", __FUNCTION__, host.c_str(), port);
+    errormessage( getLastError(), "Socket::connect" );
+    return false;
+  }
+
+  return true;
+}
+
+bool CDSSocket::reconnect()
+{
+  if ( _sd != INVALID_SOCKET )
+  {
+    return true;
+  }
+
+  if( !create() )
+    return false;
+
+  int status = ::connect ( _sd, reinterpret_cast<sockaddr*>(&_sockaddr), sizeof ( _sockaddr ) );
+
+  if ( status == SOCKET_ERROR )
+  {
+    errormessage( getLastError(), "Socket::connect" );
+    return false;
+  }
+
+  return true;
+}
+
+bool CDSSocket::is_valid() const
+{
+  return (_sd != INVALID_SOCKET);
+}
+
+
+bool CDSSocket::set_non_blocking(const bool b)
+{
+  u_long iMode;
+
+  if ( b )
+    iMode = 1;  // enable non_blocking
+  else
+    iMode = 0;  // disable non_blocking
+
+  if (ioctlsocket(_sd, FIONBIO, &iMode) == -1)
+  {
+    CLog::Log(LOGERROR, "%s Socket::set_non_blocking - Can't set socket condition to: %i", __FUNCTION__, iMode);
+    return false;
+  }
+
+  return true;
+}
+
+void CDSSocket::errormessage(int errnum, const char* functionname) const
+{
+  const char* errmsg = NULL;
+
+  switch (errnum)
+  {
+  case WSANOTINITIALISED:
+    errmsg = "A successful WSAStartup call must occur before using this function.";
+    break;
+  case WSAENETDOWN:
+    errmsg = "The network subsystem or the associated service provider has failed";
+    break;
+  case WSA_NOT_ENOUGH_MEMORY:
+    errmsg = "Insufficient memory available";
+    break;
+  case WSA_INVALID_PARAMETER:
+    errmsg = "One or more parameters are invalid";
+    break;
+  case WSA_OPERATION_ABORTED:
+    errmsg = "Overlapped operation aborted";
+    break;
+  case WSAEINTR:
+    errmsg = "Interrupted function call";
+    break;
+  case WSAEBADF:
+    errmsg = "File handle is not valid";
+    break;
+  case WSAEACCES:
+    errmsg = "Permission denied";
+    break;
+  case WSAEFAULT:
+    errmsg = "Bad address";
+    break;
+  case WSAEINVAL:
+    errmsg = "Invalid argument";
+    break;
+  case WSAENOTSOCK:
+    errmsg = "Socket operation on nonsocket";
+    break;
+  case WSAEDESTADDRREQ:
+    errmsg = "Destination address required";
+    break;
+  case WSAEMSGSIZE:
+    errmsg = "Message too long";
+    break;
+  case WSAEPROTOTYPE:
+    errmsg = "Protocol wrong type for socket";
+    break;
+  case WSAENOPROTOOPT:
+    errmsg = "Bad protocol option";
+    break;
+  case WSAEPFNOSUPPORT:
+    errmsg = "Protocol family not supported";
+    break;
+  case WSAEAFNOSUPPORT:
+    errmsg = "Address family not supported by protocol family";
+    break;
+  case WSAEADDRINUSE:
+    errmsg = "Address already in use";
+    break;
+  case WSAECONNRESET:
+    errmsg = "Connection reset by peer";
+    break;
+  case WSAHOST_NOT_FOUND:
+    errmsg = "Authoritative answer host not found";
+    break;
+  case WSATRY_AGAIN:
+    errmsg = "Nonauthoritative host not found, or server failure";
+    break;
+  case WSAEISCONN:
+    errmsg = "Socket is already connected";
+    break;
+  case WSAETIMEDOUT:
+    errmsg = "Connection timed out";
+    break;
+  case WSAECONNREFUSED:
+    errmsg = "Connection refused";
+    break;
+  case WSANO_DATA:
+    errmsg = "Valid name, no data record of requested type";
+    break;
+  default:
+    errmsg = "WSA Error";
+  }
+  CLog::Log(LOGERROR, "%s %s: (Winsock error=%i) %s", __FUNCTION__, functionname, errnum, errmsg);
+}
+
+int CDSSocket::getLastError() const
+{
+  return WSAGetLastError();
+}
+
+int CDSSocket::win_usage_count = 0; //Declared static in Socket class
+
+bool CDSSocket::osInit()
+{
+  win_usage_count++;
+  // initialize winsock:
+  if (WSAStartup(MAKEWORD(2,2),&_wsaData) != 0)
+  {
+    return false;
+  }
+
+  WORD wVersionRequested = MAKEWORD(2,2);
+
+  // check version
+  if (_wsaData.wVersion != wVersionRequested)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+void CDSSocket::osCleanup()
+{
+  win_usage_count--;
+  if(win_usage_count == 0)
+  {
+    WSACleanup();
+  }
+}
+
+#endif

--- a/xbmc/cores/DSPlayer/PVR/DSSocket.h
+++ b/xbmc/cores/DSPlayer/PVR/DSSocket.h
@@ -1,0 +1,267 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#ifndef HAS_DS_PLAYER
+#error DSPlayer's header file included without HAS_DS_PLAYER defined
+#endif
+
+
+//Include platform specific datatypes, header files, defines and constants:
+#define WIN32_LEAN_AND_MEAN             // Enable LEAN_AND_MEAN support
+#pragma warning(disable:4005)           // Disable "warning C4005: '_WINSOCKAPI_' : macro redefinition"
+#include <winsock2.h>
+#pragma warning(default:4005)
+#include <windows.h>
+
+#ifndef NI_MAXHOST
+  #define NI_MAXHOST 1025
+#endif
+
+#ifndef socklen_t
+  typedef int socklen_t;
+#endif
+#ifndef ipaddr_t
+  typedef unsigned long ipaddr_t;
+#endif
+#ifndef port_t
+  typedef unsigned short port_t;
+#endif
+#ifndef sa_family_t
+  #define sa_family_t ADDRESS_FAMILY
+#endif
+
+
+using namespace std;
+
+#include <vector>
+
+#define MAXCONNECTIONS 1  ///< Maximum number of pending connections before "Connection refused"
+#define MAXRECV 1500      ///< Maximum packet size
+
+enum SocketFamily
+{
+  af_inet = AF_INET
+};
+
+enum SocketDomain
+{
+  pf_inet = PF_INET
+};
+
+enum SocketType
+{
+  sock_stream = SOCK_STREAM,
+  sock_dgram = SOCK_DGRAM
+};
+
+enum SocketProtocol
+{
+  tcp = IPPROTO_TCP,
+  udp = IPPROTO_UDP
+};
+
+class CDSSocket
+{
+  public:
+    /*!
+     * An unconnected socket may be created directly on the local
+     * machine. The socket type (SOCK_STREAM, SOCK_DGRAM) and
+     * protocol may also be specified.
+     * If the socket cannot be created, an exception is thrown.
+     *
+     * \param family Socket family (IPv4 or IPv6)
+     * \param domain The domain parameter specifies a communications domain within which communication will take place;
+     * this selects the protocol family which should be used.
+     * \param type base type and protocol family of the socket.
+     * \param protocol specific protocol to apply.
+     */
+    CDSSocket(const enum SocketFamily family, const enum SocketDomain domain, const enum SocketType type, const enum SocketProtocol protocol = tcp);
+    CDSSocket(void);
+    virtual ~CDSSocket();
+
+    //Socket settings
+
+    /*!
+     * Socket setFamily
+     * \param family    Can be af_inet or af_inet6. Default: af_inet
+     */
+    void setFamily(const enum SocketFamily family)
+    {
+      _family = family;
+    };
+
+    /*!
+     * Socket setDomain
+     * \param domain    Can be pf_unix, pf_local, pf_inet or pf_inet6. Default: pf_inet
+     */
+    void setDomain(const enum SocketDomain domain)
+    {
+      _domain = domain;
+    };
+
+    /*!
+     * Socket setType
+     * \param type    Can be sock_stream or sock_dgram. Default: sock_stream.
+     */
+    void setType(const enum SocketType type)
+    {
+      _type = type;
+    };
+
+    /*!
+     * Socket setProtocol
+     * \param protocol    Can be tcp or udp. Default: tcp.
+     */
+    void setProtocol(const enum SocketProtocol protocol)
+    {
+      _protocol = protocol;
+    };
+
+    /*!
+     * Socket setPort
+     * \param port    port number for socket communication
+     */
+    void setPort (const unsigned short port)
+    {
+      _sockaddr.sin_port = htons ( port );
+    };
+
+    bool setHostname ( const std::string& host );
+
+    // Server initialization
+
+    /*!
+     * Socket create
+     * Create a new socket
+     * \return     True if succesful
+     */
+    bool create();
+
+    /*!
+     * Socket close
+     * Close the socket
+     * \return     True if succesful
+     */
+    bool close();
+
+    /*!
+     * Socket bind
+     */
+    bool bind ( const unsigned short port );
+    bool listen() const;
+    bool accept( CDSSocket& socket) const;
+
+    // Client initialization
+    bool connect ( const std::string& host, const unsigned short port );
+
+    bool reconnect();
+
+    // Data Transmission
+
+    /*!
+     * Socket send function
+     *
+     * \param data    Reference to a std::string with the data to transmit
+     * \return    Number of bytes send or -1 in case of an error
+     */
+    int send ( const std::string& data );
+
+    /*!
+     * Socket send function
+     *
+     * \param data    Pointer to a character array of size 'size' with the data to transmit
+     * \param size    Length of the data to transmit
+     * \return    Number of bytes send or -1 in case of an error
+     */
+    int send ( const char* data, const unsigned int size );
+
+    /*!
+     * Socket sendto function
+     *
+     * \param data    Reference to a std::string with the data to transmit
+     * \param size    Length of the data to transmit
+     * \param sendcompletebuffer    If 'true': do not return until the complete buffer is transmitted
+     * \return    Number of bytes send or -1 in case of an error
+     */
+    int sendto ( const char* data, unsigned int size, bool sendcompletebuffer = false);
+    // Data Receive
+
+    /*!
+     * Socket receive function
+     *
+     * \param data    Reference to a std::string for storage of the received data.
+     * \param minpacketsize    The minimum number of bytes that should be received before returning from this function
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int receive ( std::string& data, unsigned int minpacketsize ) const;
+
+    /*!
+     * Socket receive function
+     *
+     * \param data    Reference to a std::string for storage of the received data.
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int receive ( std::string& data ) const;
+
+    /*!
+     * Socket receive function
+     *
+     * \param data    Pointer to a character array of size buffersize. Used to store the received data.
+     * \param buffersize    Size of the 'data' buffer
+     * \param minpacketsize    Specifies the minimum number of bytes that need to be received before returning
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int receive ( char* data, const unsigned int buffersize, const unsigned int minpacketsize ) const;
+
+    /*!
+     * Socket recvfrom function
+     *
+     * \param data    Pointer to a character array of size buffersize. Used to store the received data.
+     * \param buffersize    Size of the 'data' buffer
+     * \param from        Optional: pointer to a sockaddr struct that will get the address from which the data is received
+     * \param fromlen    Optional, only required if 'from' is given: length of from struct
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int recvfrom ( char* data, const int buffersize, struct sockaddr* from = NULL, socklen_t* fromlen = NULL) const;
+
+    bool set_non_blocking ( const bool );
+
+    bool ReadLine (string& line);
+
+    bool is_valid() const;
+
+  private:
+
+    SOCKET _sd;                         ///< Socket Descriptor
+    SOCKADDR_IN _sockaddr;              ///< Socket Address
+
+    enum SocketFamily _family;          ///< Socket Address Family
+    enum SocketProtocol _protocol;      ///< Socket Protocol
+    enum SocketType _type;              ///< Socket Type
+    enum SocketDomain _domain;          ///< Socket domain
+
+    WSADATA _wsaData;                 ///< Windows Socket data
+    static int win_usage_count;       ///< Internal Windows usage counter used to prevent a global WSACleanup when more than one Socket object is used
+
+    void errormessage( int errornum, const char* functionname = NULL) const;
+    int getLastError(void) const;
+    bool osInit();
+    void osCleanup();
+};

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -46,6 +46,10 @@
 #include "utils/StringUtils.h"
 #include "utils/Observer.h"
 
+#ifdef HAS_DS_PLAYER
+#include "settings/AdvancedSettings.h"
+#endif
+
 #define MAX_INVALIDATION_FREQUENCY 2000 // limit to one invalidation per X milliseconds
 
 using namespace PVR;
@@ -382,6 +386,17 @@ bool CGUIWindowPVRBase::PlayFile(CFileItem *item, bool bPlayMinimized /* = false
       if ((g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio()) &&
          (channel->IsRadio() == g_PVRManager.IsPlayingRadio()))
       {
+#ifdef HAS_DS_PLAYER
+        if (g_advancedSettings.m_bDSPlayerFastChannelSwitching && g_application.GetCurrentPlayer() == PCID_DSPLAYER)
+        {
+          /* Workaround for MediaPortal addon, running in ffmpeg mode. */
+          // Clear StreamURL field - this will allow fast channel switching 
+          // for MediaPortal addon, running in ffmpeg mode.
+          PVR_CLIENT pvrClient;
+          if (g_PVRClients->GetPlayingClient(pvrClient) && pvrClient->GetBackendName().find("MediaPortal TV-server") != std::string::npos)
+            channel->SetStreamURL("");
+        }
+#endif
         if (channel->StreamURL().empty())
           bSwitchSuccessful = g_application.m_pPlayer->SwitchChannel(channel);
       }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -358,6 +358,11 @@ void CAdvancedSettings::Initialize()
   m_jsonOutputCompact = true;
   m_jsonTcpPort = 9090;
 
+#ifdef HAS_DS_PLAYER
+  m_bDSPlayerFastChannelSwitching = false;
+  m_bDSPlayerUseUNCPathsForLiveTV = false;
+#endif
+
   m_enableMultimediaKeys = false;
 
   m_canWindowed = true;
@@ -1131,6 +1136,13 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pDatabase, "user", m_databaseDSPlayer.user);
     XMLUtils::GetString(pDatabase, "pass", m_databaseDSPlayer.pass);
     XMLUtils::GetString(pDatabase, "name", m_databaseDSPlayer.name);
+  }
+  
+  pElement = pRootElement->FirstChildElement("dsplayer");
+  if (pElement)
+  {
+    XMLUtils::GetBoolean(pElement, "fastchannelswitching", m_bDSPlayerFastChannelSwitching);
+    XMLUtils::GetBoolean(pElement, "useuncpathsforlivetv", m_bDSPlayerUseUNCPathsForLiveTV);
   }
 #endif
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -358,6 +358,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     DatabaseSettings m_databaseEpg;   /*!< advanced EPG database setup */
 #ifdef HAS_DS_PLAYER
     DatabaseSettings m_databaseDSPlayer; // advanced DSPlayer database setup
+    bool m_bDSPlayerFastChannelSwitching; // Live TV fast channel switching (don't stop timeshift), only for MediaPortal TV-Server and ArgusTV PVR backends
+    bool m_bDSPlayerUseUNCPathsForLiveTV; // Use UNC paths for Live TV, only for MediaPortal TV-Server and ArgusTV PVR backends
 #endif
 
     bool m_guiVisualizeDirtyRegions;


### PR DESCRIPTION
**New PVR features for MediaPortal TV-Server and ArgusTV backends:**
- Live TV fast channel switching (don't stop timeshift)
- Use UNC(=SMB) paths for Live TV

**Settings in advancedsettings.xml:**

```
<advancedsettings>
  <dsplayer>
    <fastchannelswitching>true</fastchannelswitching>
    <useuncpathsforlivetv>true</useuncpathsforlivetv>
  </dsplayer>
</advancedsettings>
```
