### PR TITLE
Enable by default: "fast channel switching" and "Use UNC paths" for LiveTV

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -359,8 +359,8 @@ void CAdvancedSettings::Initialize()
   m_jsonTcpPort = 9090;
 
 #ifdef HAS_DS_PLAYER
-  m_bDSPlayerFastChannelSwitching = false;
-  m_bDSPlayerUseUNCPathsForLiveTV = false;
+  m_bDSPlayerFastChannelSwitching = true;
+  m_bDSPlayerUseUNCPathsForLiveTV = true;
 #endif
 
   m_enableMultimediaKeys = false;


### PR DESCRIPTION
Enable by default: "Live TV fast channel switching" and "Use UNC paths for Live TV"
