### PR TITLE
Disable by default: "Use UNC paths" for LiveTV

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -360,7 +360,7 @@ void CAdvancedSettings::Initialize()
 
 #ifdef HAS_DS_PLAYER
   m_bDSPlayerFastChannelSwitching = true;
-  m_bDSPlayerUseUNCPathsForLiveTV = true;
+  m_bDSPlayerUseUNCPathsForLiveTV = false;
 #endif
 
   m_enableMultimediaKeys = false;


### PR DESCRIPTION
Disable "Use UNC paths" by default, because for this feature to work,  MediaPortal users have to replace TVServerXBMC Plugin dll with my modified dll.
In the future, i hope that [my pull request ](https://github.com/margro/TVServerXBMC/pull/11) will be merged and dll replacement will not be required.
